### PR TITLE
docs: Update Value::Int references to Value::I64 (STO-126)

### DIFF
--- a/src/architecture/subsections/vmfunctions.md
+++ b/src/architecture/subsections/vmfunctions.md
@@ -97,18 +97,18 @@ let factorial_function = VMFunction {
     register_count: 5,
     instructions: vec![
         // Check if n <= 1
-        Instruction::LDI(1, Value::Int(1)),               // r1 = 1
+        Instruction::LDI(1, Value::I64(1)),               // r1 = 1
         Instruction::CMP(0, 1),                           // Compare n with 1
         Instruction::JMPEQ("base_case".to_string()),      // If n == 1, go to base case
         Instruction::CMP(1, 0),                           // Compare 1 with n
         Instruction::JMPNEQ("recursive_case".to_string()), // If not equal, go to recursive case
         Instruction::JMP("base_case".to_string()),
         // base_case: (n <= 1)
-        Instruction::LDI(0, Value::Int(1)),               // Return 1
+        Instruction::LDI(0, Value::I64(1)),               // Return 1
         Instruction::RET(0),
         // recursive_case: (n > 1)
         Instruction::MOV(3, 0),                           // r3 = n
-        Instruction::LDI(1, Value::Int(1)),               // r1 = 1
+        Instruction::LDI(1, Value::I64(1)),               // r1 = 1
         Instruction::SUB(2, 0, 1),                        // r2 = n - 1
         Instruction::PUSHARG(2),
         Instruction::CALL("factorial".to_string()),

--- a/src/getting-started/getting-started.md
+++ b/src/getting-started/getting-started.md
@@ -197,7 +197,7 @@ Integrate Rust functions:
 ```rust
 vm.register_foreign_function("double", |ctx| {
     match &ctx.args[0] {
-        Value::Int(n) => Ok(Value::Int(n * 2)),
+        Value::I64(n) => Ok(Value::I64(n * 2)),
         _ => Err("Expected integer".to_string()),
     }
 });
@@ -214,7 +214,7 @@ labels.insert("loop_end".to_string(), 6);
 
 vec![
     // Initialize counter
-    Instruction::LDI(0, Value::Int(0)),
+    Instruction::LDI(0, Value::I64(0)),
     // Compare
     Instruction::CMP(0, 1),
     Instruction::JMPEQ("loop_end".to_string()),

--- a/src/stoffel-vm/implementation.md
+++ b/src/stoffel-vm/implementation.md
@@ -75,8 +75,15 @@ The VM is designed with MPC in mind:
 ### Primitive Types
 
 ```rust
-Value::Int(i64)           // 64-bit signed integers
-Value::Float(i64)         // Fixed-point float representation
+Value::I64(i64)           // 64-bit signed integers
+Value::I32(i32)           // 32-bit signed integers
+Value::I16(i16)           // 16-bit signed integers
+Value::I8(i8)             // 8-bit signed integers
+Value::U8(u8)             // 8-bit unsigned integers
+Value::U16(u16)           // 16-bit unsigned integers
+Value::U32(u32)           // 32-bit unsigned integers
+Value::U64(u64)           // 64-bit unsigned integers
+Value::Float(F64)         // 64-bit floating point (F64 wrapper)
 Value::Bool(bool)         // Boolean values
 Value::String(String)     // UTF-8 strings
 Value::Unit               // Unit/void type
@@ -89,6 +96,7 @@ Value::Object(usize)      // Object reference (key-value pairs)
 Value::Array(usize)       // Array reference (indexed values)
 Value::Closure(Arc<Closure>) // Function closure with captured variables
 Value::Foreign(usize)     // Foreign object from host language
+Value::Share(ShareType, Vec<u8>) // Secret shared value for MPC
 ```
 
 ## Instruction Set


### PR DESCRIPTION
## Summary
- Update documentation to reflect the VM's current `Value` enum
- Change `Value::Int` to `Value::I64` in example code and type descriptions
- Fix `Value::Float` to use `F64` wrapper
- Add all integer type variants and `Share` type documentation

## Files changed
- `src/stoffel-vm/implementation.md` - Updated primitive/complex types section
- `src/getting-started/getting-started.md` - Fixed example code
- `src/architecture/subsections/vmfunctions.md` - Fixed example code

## Test plan
- [x] Run `mdbook build` to verify no build errors
- [x] Review changes match StoffelVM's `core_types.rs` Value enum

🤖 Generated with [Claude Code](https://claude.com/claude-code)