### PR TITLE
docs: Update examples to use current StoffelLang syntax

### DIFF
--- a/src/getting-started/first-project.md
+++ b/src/getting-started/first-project.md
@@ -152,12 +152,12 @@ Create `src/stats.stfl`:
 # Simple statistical functions for salary benchmarking
 
 # Calculate comprehensive salary statistics
-proc calculate_salary_stats(
+def calculate_salary_stats(
     salary_data: SalaryData,
     role_filter: int64,
     experience_filter: int64,
     location_filter: int64
-): SalaryStats =
+) -> SalaryStats:
   # Filter data for the specific role/experience/location
   let filtered_salaries: secret int64 = salary_data.salary
   let count: int64 = 1
@@ -183,7 +183,7 @@ proc calculate_salary_stats(
   )
 
 # Safely reveal statistics (with privacy protection)
-proc reveal_safe_stats(stats: SalaryStats): PublicStats =
+def reveal_safe_stats(stats: SalaryStats) -> PublicStats:
   # Only reveal if we have enough data points for statistical significance
   if stats.count < 5:
     return PublicStats(
@@ -223,7 +223,7 @@ Edit `src/main.stfl`:
 
 ```
 # Main entry point for salary benchmarking
-proc main() =
+main main() -> nil:
   print("🔒 Starting Secure Salary Benchmarking System")
   print("📊 Collecting data from participating companies...")
 
@@ -255,7 +255,7 @@ proc main() =
   print("✅ Benchmarking complete! No individual data was exposed.")
 
 # Generate a simple salary report for a specific role
-proc generate_salary_report(data: SalaryData, role_id: int64, role_name: string) =
+def generate_salary_report(data: SalaryData, role_id: int64, role_name: string) -> nil:
   print("📈 Analyzing " + role_name + " positions...")
 
   let stats = calculate_salary_stats(data, role_id, mid, high_cost)
@@ -268,7 +268,7 @@ proc generate_salary_report(data: SalaryData, role_id: int64, role_name: string)
   print("     Range: $" + $public_stats.salary_range_min + " - $" + $public_stats.salary_range_max)
 
 # Load salary data (in reality, this comes from multiple companies)
-proc load_salary_data(): SalaryData =
+def load_salary_data() -> SalaryData:
   # This would be replaced with actual data submission from companies
   # For demo purposes, we'll create some sample data
 
@@ -293,7 +293,7 @@ Create `tests/unit.stfl`:
 # Note: Testing framework syntax is simplified for demonstration
 # In practice, StoffelLang would have a proper testing framework
 
-proc test_salary_calculation() =
+def test_salary_calculation() -> nil:
   print("Testing salary statistics calculation...")
 
   # Create test data
@@ -314,7 +314,7 @@ proc test_salary_calculation() =
   else:
     print("❌ Test failed: Incorrect count")
 
-proc test_insufficient_data_protection() =
+def test_insufficient_data_protection() -> nil:
   print("Testing privacy protection...")
 
   let test_data = SalaryData(
@@ -334,7 +334,7 @@ proc test_insufficient_data_protection() =
   else:
     print("❌ Test failed: Privacy protection failed")
 
-proc main() =
+main main() -> nil:
   test_salary_calculation()
   test_insufficient_data_protection()
   print("All tests completed")

--- a/src/stoffel-lang/compilation.md
+++ b/src/stoffel-lang/compilation.md
@@ -57,7 +57,7 @@ let age: int64 = 42    # OK: Types match
 
 **Symbol Resolution:**
 ```
-proc add(a: int64, b: int64): int64 =
+def add(a: int64, b: int64) -> int64:
   return a + b  # Resolves 'a' and 'b' to parameters
 
 let result = add(10, 20)  # Resolves 'add' to function definition
@@ -72,11 +72,11 @@ StoffelLang:           Bytecode:
 let x: int64 = 42      LDI R0, 42
                       STORE x, R0
 
-proc add(a, b):        FUNCTION add:
-  return a + b           LOAD R0, a
-                        LOAD R1, b
-                        ADD R0, R0, R1
-                        RET R0
+def add(a: int64, b: int64) -> int64:   FUNCTION add:
+  return a + b                            LOAD R0, a
+                                          LOAD R1, b
+                                          ADD R0, R0, R1
+                                          RET R0
 ```
 
 ## Using the Compiler
@@ -158,14 +158,14 @@ Removes unreachable code:
 
 ```
 # Source code
-proc example(flag: bool) =
+def example(flag: bool) -> nil:
   if true:
     print("Always executed")
   else:
     print("Never executed")  # Removed by optimizer
 
 # Optimized to
-proc example(flag: bool) =
+def example(flag: bool) -> nil:
   print("Always executed")
 ```
 
@@ -175,7 +175,7 @@ Small functions may be inlined at call sites:
 
 ```
 # Source code
-proc square(x: int64): int64 =
+def square(x: int64) -> int64:
   return x * x
 
 let result = square(5)
@@ -392,14 +392,14 @@ Special considerations for MPC operations:
 
 ```
 # Expensive: Many individual secret operations
-proc inefficient(a: secret int64, b: secret int64): secret int64 =
+def inefficient(a: secret int64, b: secret int64) -> secret int64:
   let temp1 = a + 1
   let temp2 = b + 1
   let temp3 = temp1 + temp2
   return temp3 + 1
 
 # Better: Batched operations where possible
-proc efficient(a: secret int64, b: secret int64): secret int64 =
+def efficient(a: secret int64, b: secret int64) -> secret int64:
   return a + b + 2  # Compiler can optimize this
 ```
 
@@ -419,7 +419,7 @@ proc efficient(a: secret int64, b: secret int64): secret int64 =
 **"Indentation error"**
 ```bash
 # Fix: Consistent 2-space indentation
-proc example() =
+def example() -> nil:
   if true:
     print("Correct indentation")
 ```


### PR DESCRIPTION
## Summary
Update code examples in documentation to use the current StoffelLang syntax instead of the outdated `proc` keyword.

## Changes
- **`src/getting-started/first-project.md`**
  - Change `proc function_name(): ReturnType =` to `def function_name() -> ReturnType:`
  - Change `proc main() =` to `main main() -> nil:`
  
- **`src/stoffel-lang/compilation.md`**
  - Update all `proc` examples to use `def` or `main` keywords
  - Fix return type annotation syntax throughout

## Test plan
- [x] `mdbook build` succeeds
- [x] Verified code blocks use correct syntax

Related to STO-107 and STO-308

🤖 Generated with [Claude Code](https://claude.ai/claude-code)